### PR TITLE
Hotfix m1

### DIFF
--- a/.docker/web/dev.Dockerfile
+++ b/.docker/web/dev.Dockerfile
@@ -25,16 +25,11 @@ WORKDIR /home/app
 ENV NODE_ENV production
 ENV NEXT_TELEMETRY_DISABLED 1
 
-RUN addgroup --system --gid 1001 nodejs
-RUN adduser --system --uid 1001 nextjs
-
-COPY --from=builder --chown=nextjs:nodejs /home/app/.next ./.next
+COPY --from=builder /home/app/.next ./.next
 COPY --from=builder /home/app/node_modules ./node_modules
 COPY --from=builder /home/app/package.json ./package.json
 
 ENV NEXT_TELEMETRY_DISABLED 1
-
-USER nextjs
 
 EXPOSE 3000
 ENV PORT 3000

--- a/.docker/web/dev.Dockerfile
+++ b/.docker/web/dev.Dockerfile
@@ -16,7 +16,7 @@ COPY . ./
 
 ENV NEXT_TELEMETRY_DISABLED 1
 
-CMD [ "yarn", "build" ]
+RUN yarn build
 
 # Runner 
 FROM node:16-alpine AS runner 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       target: runner
     volumes:
       - .:/home/app
+      - /home/app/node_modules
     ports:
       - ${WEB_EXTERNAL_PORT}:3000
     environment:


### PR DESCRIPTION
- Construct `node_modules` if it does not exist
- Make sure to use `node_modules` in `runner` container
- Avoid user permissions problems in Linux OS