### PR TITLE
Add base standard import

### DIFF
--- a/src/view/wizardView/Step2Compile/generator.ts
+++ b/src/view/wizardView/Step2Compile/generator.ts
@@ -114,6 +114,11 @@ export function generateCode(
 
   if (standardName === 'psp22') {
     contract.addConstructorArg('initial_supply: Balance')
+    if (isCapped) {
+      contract.addConstructorAction(
+        `_instance._init_cap(initial_supply).expect("Should init cap");`
+      )
+    }
     contract.addConstructorAction(
       `_instance._mint${
         isSmallerVer(VERSION, 'v2.3.0') ? '' : '_to'

--- a/src/view/wizardView/Step2Compile/generator.ts
+++ b/src/view/wizardView/Step2Compile/generator.ts
@@ -78,6 +78,9 @@ export function generateCode(
     contract.addBrushImport(
       new Import(`${BRUSH_NAME}::contracts::${standardName}::*`)
     )
+    contract.addBrushImport(
+      new Import(`${BRUSH_NAME}::contracts::${standardName}`)
+    )
     contract.addAdditionalImpl(
       new TraitImpl(
         `${isSmallerVer(VERSION, 'v2.2.0') ? standardName.toUpperCase() : ''}${


### PR DESCRIPTION
Without this import there were a subset of contracts that failed at compilation.
Added _init_cap function call to capped extension in order to work.