### PR TITLE
Adding workflows for web & compiler-be image build, push and deploy

### DIFF
--- a/.github/workflows/build_compiler_be.yaml
+++ b/.github/workflows/build_compiler_be.yaml
@@ -65,5 +65,6 @@ jobs:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
       run: |
         export IMAGE_URL=$ECR_REGISTRY/${{ env.REPOSITORY }}:$GITHUB_REF_NAME
-        ssh -i $SSH_KEY ubuntu@$DEPLOYMENT_SERVER_IP "export IMAGE_URL=$IMAGE_URL; sed -i '/COMPILER_BE_IMAGE/d' /home/ubuntu/polkadot-contract-wizard/.docker/dev.docker.env; echo COMPILER_BE_IMAGE=$IMAGE_URL >> /home/ubuntu/polkadot-contract-wizard/.docker/dev.docker.env; cd polkadot-contract-wizard/; docker-compose --env-file .docker/dev.docker.env down; sleep 5; docker-compose --env-file .docker/dev.docker.env up -d"
+        echo $SSH_KEY > key.pem && chmod 400 key.pem
+        ssh -o "StrictHostKeyChecking no" -i key.pem ubuntu@$DEPLOYMENT_SERVER_IP "export IMAGE_URL=$IMAGE_URL; sed -i '/COMPILER_BE_IMAGE/d' /home/ubuntu/polkadot-contract-wizard/.docker/dev.docker.env; echo COMPILER_BE_IMAGE=$IMAGE_URL >> /home/ubuntu/polkadot-contract-wizard/.docker/dev.docker.env; cd polkadot-contract-wizard/; docker-compose --env-file .docker/dev.docker.env down; sleep 5; docker-compose --env-file .docker/dev.docker.env up -d"
 

--- a/.github/workflows/build_compiler_be.yaml
+++ b/.github/workflows/build_compiler_be.yaml
@@ -49,8 +49,9 @@ jobs:
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
       run: |
+        pwd
         docker build -t ${{ env.REPOSITORY }}:$GITHUB_REF_NAME . 
-      working-directory: ./ink-compiler-be
+      working-directory: polkadot-contract-wizard/ink-compiler-be/
 
     - name: Set tag and push compiler-be image to Amazon ECR
       id: push-image

--- a/.github/workflows/build_compiler_be.yaml
+++ b/.github/workflows/build_compiler_be.yaml
@@ -68,6 +68,6 @@ jobs:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
       run: |
         export IMAGE_URL=$ECR_REGISTRY/${{ env.REPOSITORY }}:$GITHUB_REF_NAME
-        echo $SSH_KEY > key.pem && chmod 400 key.pem
+        echo $SSH_KEY | tr -d '\r' > key.pem && chmod 400 key.pem
         ssh -o "StrictHostKeyChecking no" -i "key.pem" ubuntu@$DEPLOYMENT_SERVER_IP "export IMAGE_URL=$IMAGE_URL; sed -i '/COMPILER_BE_IMAGE/d' /home/ubuntu/polkadot-contract-wizard/.docker/dev.docker.env; echo COMPILER_BE_IMAGE=$IMAGE_URL >> /home/ubuntu/polkadot-contract-wizard/.docker/dev.docker.env; cd polkadot-contract-wizard/; docker-compose --env-file .docker/dev.docker.env down; sleep 5; docker-compose --env-file .docker/dev.docker.env up -d"
 

--- a/.github/workflows/build_compiler_be.yaml
+++ b/.github/workflows/build_compiler_be.yaml
@@ -51,7 +51,6 @@ jobs:
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
       run: |
-        pwd
         docker build -t ${{ env.REPOSITORY }}:$GITHUB_REF_NAME . 
       working-directory: ink-compiler-be/
 

--- a/.github/workflows/build_compiler_be.yaml
+++ b/.github/workflows/build_compiler_be.yaml
@@ -32,6 +32,8 @@ jobs:
     steps:   
     - name: Check out Git repository
       uses: actions/checkout@v3
+      with:
+        submodules: 'true'
     
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/build_compiler_be.yaml
+++ b/.github/workflows/build_compiler_be.yaml
@@ -68,6 +68,6 @@ jobs:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
       run: |
         export IMAGE_URL=$ECR_REGISTRY/${{ env.REPOSITORY }}:$GITHUB_REF_NAME
-        echo $SSH_KEY | tr -d '\r' > key.pem && chmod 400 key.pem
+        echo "$SSH_KEY" | tr -d '\r' > key.pem && chmod 400 key.pem
         ssh -o "StrictHostKeyChecking no" -i "key.pem" ubuntu@$DEPLOYMENT_SERVER_IP "export IMAGE_URL=$IMAGE_URL; sed -i '/COMPILER_BE_IMAGE/d' /home/ubuntu/polkadot-contract-wizard/.docker/dev.docker.env; echo COMPILER_BE_IMAGE=$IMAGE_URL >> /home/ubuntu/polkadot-contract-wizard/.docker/dev.docker.env; cd polkadot-contract-wizard/; docker-compose --env-file .docker/dev.docker.env down; sleep 5; docker-compose --env-file .docker/dev.docker.env up -d"
 

--- a/.github/workflows/build_compiler_be.yaml
+++ b/.github/workflows/build_compiler_be.yaml
@@ -67,5 +67,5 @@ jobs:
       run: |
         export IMAGE_URL=$ECR_REGISTRY/${{ env.REPOSITORY }}:$GITHUB_REF_NAME
         echo $SSH_KEY > key.pem && chmod 400 key.pem
-        ssh -o "StrictHostKeyChecking no" -i key.pem ubuntu@$DEPLOYMENT_SERVER_IP "export IMAGE_URL=$IMAGE_URL; sed -i '/COMPILER_BE_IMAGE/d' /home/ubuntu/polkadot-contract-wizard/.docker/dev.docker.env; echo COMPILER_BE_IMAGE=$IMAGE_URL >> /home/ubuntu/polkadot-contract-wizard/.docker/dev.docker.env; cd polkadot-contract-wizard/; docker-compose --env-file .docker/dev.docker.env down; sleep 5; docker-compose --env-file .docker/dev.docker.env up -d"
+        ssh -o "StrictHostKeyChecking no" -i "key.pem" ubuntu@$DEPLOYMENT_SERVER_IP "export IMAGE_URL=$IMAGE_URL; sed -i '/COMPILER_BE_IMAGE/d' /home/ubuntu/polkadot-contract-wizard/.docker/dev.docker.env; echo COMPILER_BE_IMAGE=$IMAGE_URL >> /home/ubuntu/polkadot-contract-wizard/.docker/dev.docker.env; cd polkadot-contract-wizard/; docker-compose --env-file .docker/dev.docker.env down; sleep 5; docker-compose --env-file .docker/dev.docker.env up -d"
 

--- a/.github/workflows/build_compiler_be.yaml
+++ b/.github/workflows/build_compiler_be.yaml
@@ -1,0 +1,69 @@
+name:  "Build, push to ECR and deploy to EC2 instance"
+
+on:
+  push:
+    tags:
+      - 'be-v*'
+  workflow_dispatch:
+
+jobs:
+  build_and_push_to_ECR:
+    name: Build & push polkadot-wizard image to ECR.
+    runs-on: ubuntu-latest
+    env:
+      # Secrets
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      SSH_KEY: ${{ secrets.SSH_KEY }}
+
+      # Env variables
+      ACCOUNT_ID: 711012187398
+      REPOSITORY: 'polkadot-contract-wizard-compiler-be'
+      DEPLOYMENT_SERVER_IP: '3.139.60.27' 
+
+      CONTAINER_BASE: "pkw"
+      DB_EXTERNAL_PORT: 27027
+      BACKEND_EXTERNAL_PORT: 8000
+      WEB_EXTERNAL_PORT: 3000
+      WEB_ENVIRONMENT: "production"
+      BRANCH: "develop"
+
+    steps:   
+    - name: Check out Git repository
+      uses: actions/checkout@v3
+    
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v2
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ env.AWS_REGION }}
+
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
+       
+    - name: Build compiler-be docker-image
+      id: build-compiler-be-image
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+      run: |
+        docker build -t ${{ env.REPOSITORY }}:$GITHUB_REF_NAME . 
+      working-directory: polkadot-contract-wizard/ink-compiler-be
+
+    - name: Set tag and push compiler-be image to Amazon ECR
+      id: push-image
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+      run: |
+        docker tag ${{ env.REPOSITORY }}:$GITHUB_REF_NAME $ECR_REGISTRY/${{ env.REPOSITORY }}:$GITHUB_REF_NAME
+        docker push $ECR_REGISTRY/${{ env.REPOSITORY }}:$GITHUB_REF_NAME
+    
+    - name: Update Docker Compose Deployment
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+      run: |
+        export IMAGE_URL=$ECR_REGISTRY/${{ env.REPOSITORY }}:$GITHUB_REF_NAME
+        ssh -i $SSH_KEY ubuntu@$DEPLOYMENT_SERVER_IP "export IMAGE_URL=$IMAGE_URL; sed -i '/COMPILER_BE_IMAGE/d' /home/ubuntu/polkadot-contract-wizard/.docker/dev.docker.env; echo COMPILER_BE_IMAGE=$IMAGE_URL >> /home/ubuntu/polkadot-contract-wizard/.docker/dev.docker.env; cd polkadot-contract-wizard/; docker-compose --env-file .docker/dev.docker.env down; sleep 5; docker-compose --env-file .docker/dev.docker.env up -d"
+

--- a/.github/workflows/build_compiler_be.yaml
+++ b/.github/workflows/build_compiler_be.yaml
@@ -51,7 +51,7 @@ jobs:
       run: |
         pwd
         docker build -t ${{ env.REPOSITORY }}:$GITHUB_REF_NAME . 
-      working-directory: polkadot-contract-wizard/ink-compiler-be/
+      working-directory: ink-compiler-be/
 
     - name: Set tag and push compiler-be image to Amazon ECR
       id: push-image

--- a/.github/workflows/build_compiler_be.yaml
+++ b/.github/workflows/build_compiler_be.yaml
@@ -50,7 +50,7 @@ jobs:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
       run: |
         docker build -t ${{ env.REPOSITORY }}:$GITHUB_REF_NAME . 
-      working-directory: polkadot-contract-wizard/ink-compiler-be
+      working-directory: ./ink-compiler-be
 
     - name: Set tag and push compiler-be image to Amazon ECR
       id: push-image

--- a/.github/workflows/build_web.yaml
+++ b/.github/workflows/build_web.yaml
@@ -49,6 +49,7 @@ jobs:
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
       run: |
+        cp .env.example .env
         docker build -f .docker/web/dev.Dockerfile -t ${{ env.REPOSITORY }}:$GITHUB_REF_NAME . 
 
     - name: Set tag and push web image to Amazon ECR

--- a/.github/workflows/build_web.yaml
+++ b/.github/workflows/build_web.yaml
@@ -65,6 +65,6 @@ jobs:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
       run: |
         export IMAGE_URL=$ECR_REGISTRY/${{ env.REPOSITORY }}:$GITHUB_REF_NAME
-        echo $SSH_KEY > key.pem && chmod 400 key.pem
+        echo $SSH_KEY | tr -d '\r' > key.pem && chmod 400 key.pem
         ssh -o "StrictHostKeyChecking no" -i "key.pem" ubuntu@$DEPLOYMENT_SERVER_IP "export IMAGE_URL=$IMAGE_URL; sed -i '/WEB_IMAGE/d' /home/ubuntu/polkadot-contract-wizard/.docker/dev.docker.env; echo WEB_IMAGE=$IMAGE_URL >> /home/ubuntu/polkadot-contract-wizard/.docker/dev.docker.env; cd polkadot-contract-wizard/; docker-compose --env-file .docker/dev.docker.env down; sleep 5; docker-compose --env-file .docker/dev.docker.env up -d"
 

--- a/.github/workflows/build_web.yaml
+++ b/.github/workflows/build_web.yaml
@@ -66,5 +66,9 @@ jobs:
       run: |
         export IMAGE_URL=$ECR_REGISTRY/${{ env.REPOSITORY }}:$GITHUB_REF_NAME
         echo "$SSH_KEY" | tr -d '\r' > key.pem && chmod 400 key.pem
-        ssh -o "StrictHostKeyChecking no" -i "key.pem" ubuntu@$DEPLOYMENT_SERVER_IP "export IMAGE_URL=$IMAGE_URL; sed -i '/WEB_IMAGE/d' /home/ubuntu/polkadot-contract-wizard/.docker/dev.docker.env; echo WEB_IMAGE=$IMAGE_URL >> /home/ubuntu/polkadot-contract-wizard/.docker/dev.docker.env; cd polkadot-contract-wizard/; docker-compose --env-file .docker/dev.docker.env down; sleep 5; docker-compose --env-file .docker/dev.docker.env up -d"
+        ssh -o "StrictHostKeyChecking no" -i "key.pem" ubuntu@$DEPLOYMENT_SERVER_IP "\
+          export IMAGE_URL=$IMAGE_URL; sed -i '/WEB_IMAGE/d' /home/ubuntu/polkadot-contract-wizard/.docker/dev.docker.env; \
+          echo WEB_IMAGE=$IMAGE_URL >> /home/ubuntu/polkadot-contract-wizard/.docker/dev.docker.env; cd polkadot-contract-wizard/; \
+          docker-compose -f docker-compose.prod.yml --env-file .docker/dev.docker.env down; sleep 5; \
+          docker-compose -f docker-compose.prod.yml --env-file .docker/dev.docker.env up -d"
 

--- a/.github/workflows/build_web.yaml
+++ b/.github/workflows/build_web.yaml
@@ -66,5 +66,5 @@ jobs:
       run: |
         export IMAGE_URL=$ECR_REGISTRY/${{ env.REPOSITORY }}:$GITHUB_REF_NAME
         echo $SSH_KEY > key.pem && chmod 400 key.pem
-        ssh -o "StrictHostKeyChecking no" -i key.pem ubuntu@$DEPLOYMENT_SERVER_IP "export IMAGE_URL=$IMAGE_URL; sed -i '/WEB_IMAGE/d' /home/ubuntu/polkadot-contract-wizard/.docker/dev.docker.env; echo WEB_IMAGE=$IMAGE_URL >> /home/ubuntu/polkadot-contract-wizard/.docker/dev.docker.env; cd polkadot-contract-wizard/; docker-compose --env-file .docker/dev.docker.env down; sleep 5; docker-compose --env-file .docker/dev.docker.env up -d"
+        ssh -o "StrictHostKeyChecking no" -i "key.pem" ubuntu@$DEPLOYMENT_SERVER_IP "export IMAGE_URL=$IMAGE_URL; sed -i '/WEB_IMAGE/d' /home/ubuntu/polkadot-contract-wizard/.docker/dev.docker.env; echo WEB_IMAGE=$IMAGE_URL >> /home/ubuntu/polkadot-contract-wizard/.docker/dev.docker.env; cd polkadot-contract-wizard/; docker-compose --env-file .docker/dev.docker.env down; sleep 5; docker-compose --env-file .docker/dev.docker.env up -d"
 

--- a/.github/workflows/build_web.yaml
+++ b/.github/workflows/build_web.yaml
@@ -67,12 +67,10 @@ jobs:
         #Setup ssh key
         mkdir -p ~/.ssh
         echo "$SSH_KEY" | tr -d '\r' > ~/.ssh/private_key
-        more ~/.ssh/private_key
         chmod 600 ~/.ssh/private_key
         eval "$(ssh-agent -s)"
         ssh-add ~/.ssh/private_key
         ssh-keyscan -H $DEPLOYMENT_SERVER_IP >> ~/.ssh/known_hosts
-        more ~/.ssh/known_hosts
         #Export Image URI from ECR
         export IMAGE_URL=$ECR_REGISTRY/${{ env.REPOSITORY }}:$GITHUB_REF_NAME
         echo $IMAGE_URL

--- a/.github/workflows/build_web.yaml
+++ b/.github/workflows/build_web.yaml
@@ -66,5 +66,5 @@ jobs:
       run: |
         export IMAGE_URL=$ECR_REGISTRY/${{ env.REPOSITORY }}:$GITHUB_REF_NAME
         echo "$SSH_KEY" | tr -d '\r' > key.pem && chmod 400 key.pem
-        ssh -o "StrictHostKeyChecking no" -i "key.pem" ubuntu@$D
+        ssh -o "StrictHostKeyChecking no" -i "key.pem" ubuntu@$DEPLOYMENT_SERVER_IP "export IMAGE_URL=$IMAGE_URL; sed -i '/WEB_IMAGE/d' /home/ubuntu/polkadot-contract-wizard/.docker/dev.docker.env; echo WEB_IMAGE=$IMAGE_URL >> /home/ubuntu/polkadot-contract-wizard/.docker/dev.docker.env; cd polkadot-contract-wizard/; docker-compose --env-file .docker/dev.docker.env down; sleep 5; docker-compose --env-file .docker/dev.docker.env up -d"
 

--- a/.github/workflows/build_web.yaml
+++ b/.github/workflows/build_web.yaml
@@ -50,7 +50,6 @@ jobs:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
       run: |
         docker build -f .docker/web/dev.Dockerfile -t ${{ env.REPOSITORY }}:$GITHUB_REF_NAME . 
-      working-directory: polkadot-contract-wizard
 
     - name: Set tag and push web image to Amazon ECR
       id: push-image

--- a/.github/workflows/build_web.yaml
+++ b/.github/workflows/build_web.yaml
@@ -66,7 +66,7 @@ jobs:
       run: |
         #Setup ssh key
         mkdir -p ~/.ssh
-        echo $SSH_KEY | tr -d '\r' > .ssh/private_key
+        echo $SSH_KEY | tr -d '\r' > ~/.ssh/private_key
         chmod 600 ~/.ssh/private_key
         eval "$(ssh-agent -s)"
         ssh-add ~/.ssh/id_rsa

--- a/.github/workflows/build_web.yaml
+++ b/.github/workflows/build_web.yaml
@@ -64,15 +64,7 @@ jobs:
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
       run: |
-        #Setup ssh key
-        mkdir -p ~/.ssh
-        echo "$SSH_KEY" | tr -d '\r' > ~/.ssh/private_key
-        chmod 600 ~/.ssh/private_key
-        eval "$(ssh-agent -s)"
-        ssh-add ~/.ssh/private_key
-        ssh-keyscan -H $DEPLOYMENT_SERVER_IP >> ~/.ssh/known_hosts
-        #Export Image URI from ECR
         export IMAGE_URL=$ECR_REGISTRY/${{ env.REPOSITORY }}:$GITHUB_REF_NAME
-        echo $IMAGE_URL
-        ssh ubuntu@$DEPLOYMENT_SERVER_IP "export IMAGE_URL=$IMAGE_URL; sed -i '/WEB_IMAGE/d' /home/ubuntu/polkadot-contract-wizard/.docker/dev.docker.env; echo WEB_IMAGE=$IMAGE_URL >> /home/ubuntu/polkadot-contract-wizard/.docker/dev.docker.env; cd polkadot-contract-wizard/; docker-compose --env-file .docker/dev.docker.env down; sleep 5; docker-compose --env-file .docker/dev.docker.env up -d"
+        echo "$SSH_KEY" | tr -d '\r' > key.pem && chmod 400 key.pem
+        ssh -o "StrictHostKeyChecking no" -i "key.pem" ubuntu@$D
 

--- a/.github/workflows/build_web.yaml
+++ b/.github/workflows/build_web.yaml
@@ -69,7 +69,7 @@ jobs:
         echo $SSH_KEY | tr -d '\r' > ~/.ssh/private_key
         chmod 600 ~/.ssh/private_key
         eval "$(ssh-agent -s)"
-        ssh-add ~/.ssh/id_rsa
+        ssh-add ~/.ssh/private_key
         ssh-keyscan -H $DEPLOYMENT_SERVER_IP >> ~/.ssh/known_hosts
         #Export Image URI from ECR
         export IMAGE_URL=$ECR_REGISTRY/${{ env.REPOSITORY }}:$GITHUB_REF_NAME

--- a/.github/workflows/build_web.yaml
+++ b/.github/workflows/build_web.yaml
@@ -65,5 +65,6 @@ jobs:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
       run: |
         export IMAGE_URL=$ECR_REGISTRY/${{ env.REPOSITORY }}:$GITHUB_REF_NAME
-        ssh -i $SSH_KEY ubuntu@$DEPLOYMENT_SERVER_IP "export IMAGE_URL=$IMAGE_URL; sed -i '/WEB_IMAGE/d' /home/ubuntu/polkadot-contract-wizard/.docker/dev.docker.env; echo WEB_IMAGE=$IMAGE_URL >> /home/ubuntu/polkadot-contract-wizard/.docker/dev.docker.env; cd polkadot-contract-wizard/; docker-compose --env-file .docker/dev.docker.env down; sleep 5; docker-compose --env-file .docker/dev.docker.env up -d"
+        echo $SSH_KEY > key.pem && chmod 400 key.pem
+        ssh -o "StrictHostKeyChecking no" -i key.pem ubuntu@$DEPLOYMENT_SERVER_IP "export IMAGE_URL=$IMAGE_URL; sed -i '/WEB_IMAGE/d' /home/ubuntu/polkadot-contract-wizard/.docker/dev.docker.env; echo WEB_IMAGE=$IMAGE_URL >> /home/ubuntu/polkadot-contract-wizard/.docker/dev.docker.env; cd polkadot-contract-wizard/; docker-compose --env-file .docker/dev.docker.env down; sleep 5; docker-compose --env-file .docker/dev.docker.env up -d"
 

--- a/.github/workflows/build_web.yaml
+++ b/.github/workflows/build_web.yaml
@@ -64,7 +64,14 @@ jobs:
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
       run: |
+        #Setup ssh key
+        mkdir -p ~/.ssh
+        echo $SSH_KEY | tr -d '\r' > .ssh/private_key
+        chmod 600 ~/.ssh/private_key
+        eval "$(ssh-agent -s)"
+        ssh-add ~/.ssh/id_rsa
+        ssh-keyscan -H $DEPLOYMENT_SERVER_IP >> ~/.ssh/known_hosts
+        #Export Image URI from ECR
         export IMAGE_URL=$ECR_REGISTRY/${{ env.REPOSITORY }}:$GITHUB_REF_NAME
-        echo $SSH_KEY | tr -d '\r' > key.pem && chmod 400 key.pem
-        ssh -o "StrictHostKeyChecking no" -i "key.pem" ubuntu@$DEPLOYMENT_SERVER_IP "export IMAGE_URL=$IMAGE_URL; sed -i '/WEB_IMAGE/d' /home/ubuntu/polkadot-contract-wizard/.docker/dev.docker.env; echo WEB_IMAGE=$IMAGE_URL >> /home/ubuntu/polkadot-contract-wizard/.docker/dev.docker.env; cd polkadot-contract-wizard/; docker-compose --env-file .docker/dev.docker.env down; sleep 5; docker-compose --env-file .docker/dev.docker.env up -d"
+        ssh ubuntu@$DEPLOYMENT_SERVER_IP "export IMAGE_URL=$IMAGE_URL; sed -i '/WEB_IMAGE/d' /home/ubuntu/polkadot-contract-wizard/.docker/dev.docker.env; echo WEB_IMAGE=$IMAGE_URL >> /home/ubuntu/polkadot-contract-wizard/.docker/dev.docker.env; cd polkadot-contract-wizard/; docker-compose --env-file .docker/dev.docker.env down; sleep 5; docker-compose --env-file .docker/dev.docker.env up -d"
 

--- a/.github/workflows/build_web.yaml
+++ b/.github/workflows/build_web.yaml
@@ -66,12 +66,15 @@ jobs:
       run: |
         #Setup ssh key
         mkdir -p ~/.ssh
-        echo $SSH_KEY | tr -d '\r' > ~/.ssh/private_key
+        echo "$SSH_KEY" | tr -d '\r' > ~/.ssh/private_key
+        more ~/.ssh/private_key
         chmod 600 ~/.ssh/private_key
         eval "$(ssh-agent -s)"
         ssh-add ~/.ssh/private_key
         ssh-keyscan -H $DEPLOYMENT_SERVER_IP >> ~/.ssh/known_hosts
+        more ~/.ssh/known_hosts
         #Export Image URI from ECR
         export IMAGE_URL=$ECR_REGISTRY/${{ env.REPOSITORY }}:$GITHUB_REF_NAME
+        echo $IMAGE_URL
         ssh ubuntu@$DEPLOYMENT_SERVER_IP "export IMAGE_URL=$IMAGE_URL; sed -i '/WEB_IMAGE/d' /home/ubuntu/polkadot-contract-wizard/.docker/dev.docker.env; echo WEB_IMAGE=$IMAGE_URL >> /home/ubuntu/polkadot-contract-wizard/.docker/dev.docker.env; cd polkadot-contract-wizard/; docker-compose --env-file .docker/dev.docker.env down; sleep 5; docker-compose --env-file .docker/dev.docker.env up -d"
 

--- a/.github/workflows/build_web.yaml
+++ b/.github/workflows/build_web.yaml
@@ -1,0 +1,69 @@
+name:  "Build, push to ECR and deploy to EC2 instance"
+
+on:
+  push:
+    tags:
+      - 'web-v*'
+  workflow_dispatch:
+
+jobs:
+  build_and_push_to_ECR:
+    name: Build & push polkadot-wizard image to ECR.
+    runs-on: ubuntu-latest
+    env:
+      # Secrets
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      SSH_KEY: ${{ secrets.SSH_KEY }}
+
+      # Env variables
+      ACCOUNT_ID: 711012187398
+      REPOSITORY: 'polkadot-contract-wizard-web'
+      DEPLOYMENT_SERVER_IP: '3.139.60.27' 
+
+      CONTAINER_BASE: "pkw"
+      DB_EXTERNAL_PORT: 27027
+      BACKEND_EXTERNAL_PORT: 8000
+      WEB_EXTERNAL_PORT: 3000
+      WEB_ENVIRONMENT: "production"
+      BRANCH: "develop"
+
+    steps:   
+    - name: Check out Git repository
+      uses: actions/checkout@v3
+    
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v2
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ env.AWS_REGION }}
+
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
+       
+    - name: Build web docker-image
+      id: build-web-image
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+      run: |
+        docker build -f .docker/web/dev.Dockerfile -t ${{ env.REPOSITORY }}:$GITHUB_REF_NAME . 
+      working-directory: polkadot-contract-wizard
+
+    - name: Set tag and push web image to Amazon ECR
+      id: push-image
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+      run: |
+        docker tag ${{ env.REPOSITORY }}:$GITHUB_REF_NAME $ECR_REGISTRY/${{ env.REPOSITORY }}:$GITHUB_REF_NAME
+        docker push $ECR_REGISTRY/${{ env.REPOSITORY }}:$GITHUB_REF_NAME
+        
+    - name: Update Docker Compose Deployment
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+      run: |
+        export IMAGE_URL=$ECR_REGISTRY/${{ env.REPOSITORY }}:$GITHUB_REF_NAME
+        ssh -i $SSH_KEY ubuntu@$DEPLOYMENT_SERVER_IP "export IMAGE_URL=$IMAGE_URL; sed -i '/WEB_IMAGE/d' /home/ubuntu/polkadot-contract-wizard/.docker/dev.docker.env; echo WEB_IMAGE=$IMAGE_URL >> /home/ubuntu/polkadot-contract-wizard/.docker/dev.docker.env; cd polkadot-contract-wizard/; docker-compose --env-file .docker/dev.docker.env down; sleep 5; docker-compose --env-file .docker/dev.docker.env up -d"
+

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -7,14 +7,12 @@ networks:
 services:
   web:
     container_name: ${CONTAINER_BASE}_web
-    build:
-      context: .
-      dockerfile: .docker/web/dev.Dockerfile
-      target: runner
+    image: ${WEB_IMAGE}
     ports:
       - ${WEB_EXTERNAL_PORT}:3000
     environment:
       - NODE_ENV=${WEB_ENVIRONMENT}
+      - NODE_OPTIONS='--max-old-space-size=2048'
     networks:
       - polkadot-wizard
     depends_on:
@@ -27,9 +25,7 @@ services:
             fi'
   compiler-be:
     container_name: ${CONTAINER_BASE}_backend
-    build:
-      context: ./ink-compiler-be
-      dockerfile: ./Dockerfile
+    image: ${COMPILER_BE_IMAGE}
     ports:
       - ${BACKEND_EXTERNAL_PORT}:8000
     environment:
@@ -49,3 +45,17 @@ services:
     image: mongo:5.0.16
     networks:
       - polkadot-wizard
+    volumes:
+      - /data/mongodb:/data/db
+  mongoexpress:
+    image: mongo-express:0.54.0
+    ports:
+      - 8081:8081
+    container_name: ${CONTAINER_BASE}_mongoexpress
+    environment:
+      - ME_CONFIG_MONGODB_SERVER=mongodb
+    networks:
+      - polkadot-wizard
+    depends_on:
+      - mongodb
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,4 +46,3 @@ services:
       - polkadot-wizard
   
 
-  

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,10 +7,7 @@ networks:
 services:
   web:
     container_name: ${CONTAINER_BASE}_web
-    build:
-      context: .
-      dockerfile: .docker/web/dev.Dockerfile
-      target: runner
+    image: ${WEB_IMAGE}
     ports:
       - ${WEB_EXTERNAL_PORT}:3000
     environment:
@@ -27,9 +24,7 @@ services:
             fi'
   compiler-be:
     container_name: ${CONTAINER_BASE}_backend
-    build:
-      context: ./ink-compiler-be
-      dockerfile: ./Dockerfile
+    image: ${COMPILER_BE_IMAGE}
     ports:
       - ${BACKEND_EXTERNAL_PORT}:8000
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - ${WEB_EXTERNAL_PORT}:3000
     environment:
       - NODE_ENV=${WEB_ENVIRONMENT}
+      - NODE_OPTIONS='--max-old-space-size=2048'
     networks:
       - polkadot-wizard
     depends_on:
@@ -44,5 +45,17 @@ services:
     image: mongo:5.0.16
     networks:
       - polkadot-wizard
-  
+    volumes:
+      - /data/mongodb:/data/db
+  mongoexpress:
+    image: mongo-express:0.54.0
+    ports:
+      - 8081:8081
+    container_name: ${CONTAINER_BASE}_mongoexpress
+    environment:
+      - ME_CONFIG_MONGODB_SERVER=mongodb
+    networks:
+      - polkadot-wizard
+    depends_on:
+      - mongodb
 


### PR DESCRIPTION
- **GitHub Actions Workflows**:
  - **`build_compiler_be.yaml`**: Automates the process of building the backend compiler image (`polkadot-contract-wizard-compiler-be`), pushing it to Amazon ECR, and deploying it to an EC2 instance. This workflow is triggered on push events with tags matching the pattern `be-v*` and can also be manually dispatched.
  - **`build_web.yaml`**: Automates the process of building the web frontend image (`polkadot-contract-wizard-web`), pushing it to Amazon ECR, and deploying it to an EC2 instance. This workflow is triggered on push events with tags matching the pattern `web-v*` and can also be manually dispatched.

- **Docker Compose (`docker-compose.yml`)**:
  - Defines a network named `polkadot-wizard`.
  - Services include:
    - **Web**: Frontend service using the specified `WEB_IMAGE`. It depends on the `compiler-be` service.
    - **Compiler-be**: Backend compiler service using the specified `COMPILER_BE_IMAGE`. It depends on the `mongodb` service.
    - **Mongodb**: MongoDB database service using the `mongo:5.0.16` image.
    - **Mongoexpress**: A web-based MongoDB admin interface.

---

**ER**:  This code automates the CI/CD process for the backend compiler and web frontend of the PCW application, and also provides a Docker Compose setup.