### PR TITLE
Remove usesStandardExtensions from ac enumerable

### DIFF
--- a/src/view/wizardView/Step2Compile/getExtensions.ts
+++ b/src/view/wizardView/Step2Compile/getExtensions.ts
@@ -47,8 +47,6 @@ export function getExtensions(
         []
       )
     )
-
-    usesStandardExtensions = true
   }
 
   // Batch extension


### PR DESCRIPTION
When we generate the code for the Access control enumerable feature we also need to add another import:
```rust
#![cfg_attr(not(feature = "std"), no_std)]
#![feature(min_specialization)]

#[openbrush::contract]
pub mod my_psp22 {
    // imports from openbrush

    //This is the missing import to make it work
    use openbrush::contracts::psp22::*;


    use openbrush::contracts::access_control::extensions::enumerable::*;
    use openbrush::contracts::access_control::only_role;
    use openbrush::traits::Storage;

    #[ink(storage)]
    #[derive(Default, Storage)]
    pub struct Contract {
        #[storage_field]
        psp22: psp22::Data,
        #[storage_field]
        access: access_control::Data<Members>,
    }

...
```
